### PR TITLE
fix(py): canonicalization aligned with JS

### DIFF
--- a/scripts/common_canonical.py
+++ b/scripts/common_canonical.py
@@ -1,7 +1,5 @@
 import json
-
 SUBSET_KEYS = ["id","issued_at","input_hash","output_hash","model_version","policy_version"]
-
 def canonicalize_subset_bytes(receipt: dict) -> bytes:
     obj = {}
     for k in SUBSET_KEYS:

--- a/scripts/make_signed_ed25519.py
+++ b/scripts/make_signed_ed25519.py
@@ -1,13 +1,9 @@
-import sys, json, base64, os
+import sys, json, base64
 from nacl.signing import SigningKey
 from common_canonical import canonicalize_subset_bytes
-
-# cheie demo deterministă (NU pt. producție)
 SEED = bytes([1]*32)
-
 def main(out_path):
-    sk = SigningKey(SEED)
-    vk = sk.verify_key
+    sk = SigningKey(SEED); vk = sk.verify_key
     r = {
         "id":"rec_py_interop",
         "issued_at":"2025-09-10T12:00:00Z",
@@ -25,8 +21,5 @@ def main(out_path):
     }
     with open(out_path,"w",encoding="utf-8") as f:
         json.dump(r,f,ensure_ascii=False,separators=(',',':'))
-
 if __name__ == "__main__":
-    out = sys.argv[1]
-    main(out)
-    print(f"Wrote {out}")
+    main(sys.argv[1]); print(f"Wrote {sys.argv[1]}")

--- a/scripts/verify_ed25519_real.py
+++ b/scripts/verify_ed25519_real.py
@@ -5,9 +5,8 @@ from common_canonical import canonicalize_subset_bytes
 
 def verify_signature(receipt: dict):
     s = receipt.get("signature")
-    if not s:
-        return False, "not_provided"
-    if s.get("alg") != "ed25519" or not s.get("sig") or not str(s.get("kid","")).startswith("ed25519:"):
+    if not s: return False, "not_provided"
+    if s.get("alg")!="ed25519" or not s.get("sig") or not str(s.get("kid","")).startswith("ed25519:"):
         return False, "unsupported_alg"
     pub_hex = s["kid"].split(":",1)[1]
     pub = VerifyKey(bytes.fromhex(pub_hex))
@@ -21,8 +20,7 @@ def verify_signature(receipt: dict):
 
 if __name__ == "__main__":
     p = sys.argv[1]
-    with open(p, "r", encoding="utf-8") as f:
-        r = json.load(f)
+    with open(p,"r",encoding="utf-8") as f: r = json.load(f)
     ok, reason = verify_signature(r)
     print(f"signature: {'PASS' if ok else 'FAIL'} ({reason})")
     sys.exit(0 if ok else 1)


### PR DESCRIPTION
Match JSON.stringify: separators=(',',':'), ensure_ascii=False, fixed key order.